### PR TITLE
Add Codecov upload step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
         id: npm-ci-test
         run: npm run ci-test
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: 3fd51631-9221-4998-8aea-0db320adb4de
+
   test-action:
     name: GitHub Actions Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the step to upload coverage reports to Codecov in the CI workflow.
- **Integration with Codecov**: Adds a new step in the `.github/workflows/ci.yml` file to upload coverage reports to Codecov using `codecov/codecov-action@v4.0.1` with the specified token. This step is added after the test step in the `test-typescript` job.

Resolves #5
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yurishkuro/issues-manager?shareId=a16e2080-1d7c-49bd-ba53-8f7a807c216f).